### PR TITLE
Security: fix HIGH-priority audit findings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,8 @@
 # This is the critical exclusion: a local build must never bake these in.
 newtarr-config/
 config/
+.env
+.env.*
 
 # Editor / IDE / agent metadata
 .idea

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,55 @@
+# Keep secrets, local runtime data, and build cruft out of the image.
+# The Dockerfile uses `COPY . /app/`; anything not excluded here is shipped.
+
+# Version control & CI
+.git
+.gitignore
+.github
+
+# Local runtime data — config, secrets (.secret_key), logs, state.
+# This is the critical exclusion: a local build must never bake these in.
+newtarr-config/
+config/
+
+# Editor / IDE / agent metadata
+.idea
+.vscode
+.claude
+*.iml
+*.swp
+*.swo
+
+# Python caches & virtual environments
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.venv/
+venv/
+env/
+ENV/
+*.egg-info/
+.eggs/
+
+# Tooling caches
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+
+# Docs & project meta — not needed at runtime
+*.md
+docs/
+SECURITY-AUDIT.md
+
+# Build / packaging metadata not needed inside the image
+Dockerfile
+.dockerignore
+docker-compose.yml
+Makefile
+renovate.json
+
+# OS noise
+.DS_Store
+*.log

--- a/src/primary/default_configs/general.json
+++ b/src/primary/default_configs/general.json
@@ -7,7 +7,7 @@
   "enable_notifications": false,
   "notification_level": "info",
   "local_access_bypass": false,
-  "proxy_auth_bypass": true,
+  "proxy_auth_bypass": false,
   "stateful_management_hours": 168,
   "command_wait_delay": 1,
   "command_wait_attempts": 600,


### PR DESCRIPTION
Fixes the two HIGH-severity findings from the repo security audit.

## 1. Add `.dockerignore` (secret exposure)

The Dockerfile does `COPY . /app/` with no `.dockerignore`. A local `docker build` — the documented `docker compose up --build` workflow, which bind-mounts `./newtarr-config` — bakes the entire working tree into the image, including:

- `newtarr-config/settings/.secret_key` — the **live Flask session-signing secret**
- `newtarr-config/` logs and state
- the full `.git/` history
- `SECURITY-AUDIT.md`

Anyone who pulls such an image gets the session secret (→ session forgery). The new `.dockerignore` excludes local runtime data, VCS, IDE/agent metadata, caches, and docs, while keeping everything the runtime needs (`main.py`, `src/`, `frontend/`, `version.txt`, `requirements.txt`). CI builds from a clean checkout were already safe; this protects local builds and also drops `.git` from the image.

## 2. Disable `proxy_auth_bypass` by default (auth bypass)

`proxy_auth_bypass` defaulted to `true`. `authenticate_request()` checks it *before* `user_exists()` and returns "allow" for every route, so a fresh standalone deployment had **no authentication at all** — settings, *arr API keys, and logs were readable/writable by anyone reaching the port.

Default is now `false`. `load_settings()` only fills in *missing* default keys without overwriting existing values, so:

- **Existing ElfHosted/SSO installs** already have `proxy_auth_bypass: true` saved → **unaffected**.
- **Fresh installs** get the secure default and are routed through the setup/login flow.
- SSO-proxied deployments opt back in by setting `proxy_auth_bypass: true` explicitly in their config provisioning.

No migration needed; no breakage for current users.

## Notes

- Not in scope here: the MEDIUM findings (CSRF, session cookie flags, login rate limiting) and the stale `SECURITY-AUDIT.md` / README "Security" section, which still describe already-fixed issues.
- I did not run a full `docker build` to verify the `.dockerignore` (the `dhi.io/python` base is network-restricted in my environment). The exclusion patterns were verified by inspection to not match any runtime-required path.