### PR TITLE
Security: fix MEDIUM-priority audit findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,8 @@ There is no test framework or linter configured. The app runs on port 9705.
 - `PORT` — Server port (default: 9705)
 - `DEBUG` — Enable debug logging
 - `TZ` — Timezone (default: UTC)
+- `NEWTARR_SESSION_COOKIE_SECURE` — Set to `true` to mark the session cookie `Secure` (enable when serving over HTTPS/TLS; default: `false`)
+- `NEWTARR_TRUSTED_ORIGINS` — Comma-separated extra origins accepted by the CSRF check; needed only for reverse proxies that do not preserve the original `Host` header
 
 ## Dependencies
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,12 @@ docker compose up --build
 
 # Build image only
 docker build -t newtarr .
+
+# Run unit tests (stdlib unittest, no extra deps beyond requirements.txt)
+python -m unittest discover -s tests -v
 ```
 
-There is no test framework or linter configured. The app runs on port 9705.
+The app runs on port 9705. No linter is configured. Tests live under `tests/` and cover pure helpers only (no Flask app, no /config writes).
 
 ## Architecture
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,10 @@ COPY . /app/
 # Set environment variables
 ENV PYTHONPATH=/app
 
+# Run as the non-root user (uid/gid 65532). /config is owned by this user and
+# the app binds an unprivileged port, so no root capabilities are required.
+USER 65532:65532
+
 # Expose port
 EXPOSE 9705
 

--- a/src/primary/auth.py
+++ b/src/primary/auth.py
@@ -53,6 +53,26 @@ def _is_local_ip(addr: str) -> bool:
     return ip.is_loopback or ip.is_link_local or ip.is_private
 
 
+def _resolve_client_ip(remote_addr: Optional[str], forwarded_for: Optional[str]) -> Optional[str]:
+    """Derive the real client IP from the direct peer and an X-Forwarded-For
+    header. XFF is only honored when the direct peer is itself local —
+    otherwise XFF is attacker-controlled and ignored."""
+    if not remote_addr:
+        return None
+    if forwarded_for and _is_local_ip(remote_addr):
+        # First entry in the chain is the originating client.
+        client = forwarded_for.split(',')[0].strip()
+        if client:
+            return client
+    return remote_addr
+
+
+def get_client_ip() -> Optional[str]:
+    """Return the real client IP for the current Flask request, honoring
+    X-Forwarded-For only when the direct peer is a local reverse proxy."""
+    return _resolve_client_ip(request.remote_addr, request.headers.get('X-Forwarded-For'))
+
+
 # --- Login rate limiting --------------------------------------------------
 # Tracks failed login attempts per source IP to slow online brute-force
 # attacks. State is in-memory (single-process Waitress deployment), mirroring
@@ -405,31 +425,19 @@ def authenticate_request():
         pass
 
     remote_addr = request.remote_addr
-    logger.info(f"Request IP address: {remote_addr}")
+    client_ip = get_client_ip()
+    logger.info(f"Request IP address: {client_ip} (peer {remote_addr})")
 
     if local_access_bypass:
-        # When a local reverse proxy forwards the request, the real client is
-        # in X-Forwarded-For. Only trust XFF when the direct peer (remote_addr)
-        # is itself local — otherwise XFF is attacker-controlled and spoofable.
-        remote_is_local = _is_local_ip(remote_addr)
         forwarded_for = request.headers.get('X-Forwarded-For')
+        if forwarded_for and not _is_local_ip(remote_addr):
+            logger.warning(f"Ignoring X-Forwarded-For header from untrusted source ({remote_addr})")
 
-        if forwarded_for and remote_is_local:
-            # First entry in the chain is the originating client.
-            client_ip = forwarded_for.split(',')[0].strip()
-            logger.debug(f"X-Forwarded-For from trusted proxy ({remote_addr}): {forwarded_for}")
-            is_local = _is_local_ip(client_ip)
-            logger.info(f"Forwarded client IP {client_ip} local={is_local}")
-        else:
-            if forwarded_for and not remote_is_local:
-                logger.warning(f"Ignoring X-Forwarded-For header from untrusted source ({remote_addr})")
-            is_local = remote_is_local
-
-        if is_local:
-            logger.info(f"Local network access from {remote_addr} - Authentication bypassed (Local Bypass Mode)")
+        if _is_local_ip(client_ip):
+            logger.info(f"Local network access from {client_ip} - Authentication bypassed (Local Bypass Mode)")
             return None
         else:
-            logger.warning(f"Access from {remote_addr} is not recognized as local network - Authentication required")
+            logger.warning(f"Access from {client_ip} is not recognized as local network - Authentication required")
     else:
         logger.info("Local Bypass Mode is DISABLED - Authentication required")
 

--- a/src/primary/auth.py
+++ b/src/primary/auth.py
@@ -10,6 +10,8 @@ import json
 import hashlib
 import secrets
 import time
+import ipaddress
+import threading
 import pathlib
 import base64
 import io
@@ -32,6 +34,73 @@ SESSION_COOKIE_NAME = "newtarr_session"
 
 # Store active sessions
 active_sessions = {}
+
+
+# --- Local network detection ---------------------------------------------
+
+def _is_local_ip(addr: str) -> bool:
+    """Return True if addr is a loopback, link-local, or private (RFC1918/ULA)
+    address. Used by the local_access_bypass auth mode."""
+    if not addr:
+        return False
+    try:
+        ip = ipaddress.ip_address(addr.strip())
+    except ValueError:
+        return False
+    # Unwrap IPv4-mapped IPv6 addresses (e.g. ::ffff:192.168.1.5)
+    if ip.version == 6 and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return ip.is_loopback or ip.is_link_local or ip.is_private
+
+
+# --- Login rate limiting --------------------------------------------------
+# Tracks failed login attempts per source IP to slow online brute-force
+# attacks. State is in-memory (single-process Waitress deployment), mirroring
+# how active_sessions is handled.
+_LOGIN_ATTEMPT_WINDOW = 300   # seconds
+_LOGIN_MAX_ATTEMPTS = 10      # failed attempts allowed per window
+_login_attempts: Dict[str, list] = {}
+_login_attempts_lock = threading.Lock()
+
+
+def _recent_attempts(ip: str, now: float) -> list:
+    """Return this IP's failed-attempt timestamps still within the window."""
+    return [t for t in _login_attempts.get(ip, []) if now - t < _LOGIN_ATTEMPT_WINDOW]
+
+
+def login_rate_limited(ip: str) -> bool:
+    """Return True if this IP has exceeded the failed-login limit."""
+    if not ip:
+        return False
+    now = time.time()
+    with _login_attempts_lock:
+        attempts = _recent_attempts(ip, now)
+        _login_attempts[ip] = attempts
+        return len(attempts) >= _LOGIN_MAX_ATTEMPTS
+
+
+def record_failed_login(ip: str) -> None:
+    """Record a failed login attempt for this IP."""
+    if not ip:
+        return
+    now = time.time()
+    with _login_attempts_lock:
+        attempts = _recent_attempts(ip, now)
+        attempts.append(now)
+        _login_attempts[ip] = attempts
+        # Opportunistically drop IPs whose attempts have all aged out.
+        for stale_ip in [k for k, v in _login_attempts.items()
+                         if not any(now - t < _LOGIN_ATTEMPT_WINDOW for t in v)]:
+            del _login_attempts[stale_ip]
+
+
+def clear_failed_logins(ip: str) -> None:
+    """Clear recorded failures for this IP (call on successful login)."""
+    if not ip:
+        return
+    with _login_attempts_lock:
+        _login_attempts.pop(ip, None)
+
 
 # --- Add Helper functions for user data ---
 def get_user_data() -> Dict[str, Any]:
@@ -339,47 +408,25 @@ def authenticate_request():
     logger.info(f"Request IP address: {remote_addr}")
 
     if local_access_bypass:
-        # Common local network IP ranges
-        local_networks = [
-            '127.0.0.1',      # localhost
-            '::1',            # localhost IPv6
-            '10.',            # 10.0.0.0/8
-            '192.168.'        # 192.168.0.0/16
-        ]
-        is_local = False
-
-        # Only trust X-Forwarded-For when the direct connection is from a local/trusted IP
-        # (i.e., the request is coming through a local reverse proxy)
+        # When a local reverse proxy forwards the request, the real client is
+        # in X-Forwarded-For. Only trust XFF when the direct peer (remote_addr)
+        # is itself local — otherwise XFF is attacker-controlled and spoofable.
+        remote_is_local = _is_local_ip(remote_addr)
         forwarded_for = request.headers.get('X-Forwarded-For')
-        remote_is_local = any(
-            remote_addr == network or (network.endswith('.') and remote_addr.startswith(network))
-            for network in local_networks
-        )
+
         if forwarded_for and remote_is_local:
-            logger.debug(f"X-Forwarded-For header detected from trusted proxy ({remote_addr}): {forwarded_for}")
-            # Take the first IP in the chain which is typically the client's real IP
-            possible_client_ip = forwarded_for.split(',')[0].strip()
-            logger.debug(f"Checking if forwarded IP {possible_client_ip} is local")
-
-            # Check if this forwarded IP is a local network IP
-            for network in local_networks:
-                if possible_client_ip == network or (network.endswith('.') and possible_client_ip.startswith(network)):
-                    is_local = True
-                    logger.info(f"Forwarded IP {possible_client_ip} is a local network IP (matches {network})")
-                    break
-        elif forwarded_for and not remote_is_local:
-            logger.warning(f"Ignoring X-Forwarded-For header from untrusted source ({remote_addr})")
-
-        # Check if direct remote_addr is a local network IP if not already determined
-        if not is_local:
-            for network in local_networks:
-                if remote_addr == network or (network.endswith('.') and remote_addr.startswith(network)):
-                    is_local = True
-                    logger.info(f"Direct IP {remote_addr} is a local network IP (matches {network})")
-                    break
+            # First entry in the chain is the originating client.
+            client_ip = forwarded_for.split(',')[0].strip()
+            logger.debug(f"X-Forwarded-For from trusted proxy ({remote_addr}): {forwarded_for}")
+            is_local = _is_local_ip(client_ip)
+            logger.info(f"Forwarded client IP {client_ip} local={is_local}")
+        else:
+            if forwarded_for and not remote_is_local:
+                logger.warning(f"Ignoring X-Forwarded-For header from untrusted source ({remote_addr})")
+            is_local = remote_is_local
 
         if is_local:
-            logger.info(f"Local network access from {remote_addr} - Authentication bypassed! (Local Bypass Mode)")
+            logger.info(f"Local network access from {remote_addr} - Authentication bypassed (Local Bypass Mode)")
             return None
         else:
             logger.warning(f"Access from {remote_addr} is not recognized as local network - Authentication required")

--- a/src/primary/routes/common.py
+++ b/src/primary/routes/common.py
@@ -17,7 +17,7 @@ from ..auth import (
     change_username as auth_change_username, change_password as auth_change_password,
     validate_password_strength, logout, verify_session, disable_2fa_with_password_and_otp,
     user_exists, create_user, generate_2fa_secret, verify_2fa_code, is_2fa_enabled, # Add missing auth imports
-    login_rate_limited, record_failed_login, clear_failed_logins
+    login_rate_limited, record_failed_login, clear_failed_logins, get_client_ip
 )
 from ..utils.logger import logger # Ensure logger is imported
 from .. import settings_manager # Import settings_manager
@@ -54,8 +54,10 @@ def login_route():
                  logger.warning("Login attempt with missing username or password.")
                  return jsonify({"success": False, "error": "Username and password are required"}), 400
 
-            # Throttle online brute-force attacks
-            client_ip = request.remote_addr
+            # Throttle online brute-force attacks. Use the real client IP
+            # (X-Forwarded-For when the peer is a trusted local proxy) so a
+            # single attacker behind a shared proxy can't lock out other users.
+            client_ip = get_client_ip()
             if login_rate_limited(client_ip):
                 logger.warning(f"Login blocked: too many failed attempts from {client_ip}")
                 return jsonify({

--- a/src/primary/routes/common.py
+++ b/src/primary/routes/common.py
@@ -16,7 +16,8 @@ from ..auth import (
     verify_user, create_session, get_username_from_session, SESSION_COOKIE_NAME,
     change_username as auth_change_username, change_password as auth_change_password,
     validate_password_strength, logout, verify_session, disable_2fa_with_password_and_otp,
-    user_exists, create_user, generate_2fa_secret, verify_2fa_code, is_2fa_enabled # Add missing auth imports
+    user_exists, create_user, generate_2fa_secret, verify_2fa_code, is_2fa_enabled, # Add missing auth imports
+    login_rate_limited, record_failed_login, clear_failed_logins
 )
 from ..utils.logger import logger # Ensure logger is imported
 from .. import settings_manager # Import settings_manager
@@ -53,6 +54,15 @@ def login_route():
                  logger.warning("Login attempt with missing username or password.")
                  return jsonify({"success": False, "error": "Username and password are required"}), 400
 
+            # Throttle online brute-force attacks
+            client_ip = request.remote_addr
+            if login_rate_limited(client_ip):
+                logger.warning(f"Login blocked: too many failed attempts from {client_ip}")
+                return jsonify({
+                    "success": False,
+                    "error": "Too many failed login attempts. Please wait a few minutes and try again."
+                }), 429
+
             # Call verify_user which now returns (auth_success, needs_2fa)
             auth_success, needs_2fa = verify_user(username, password, twoFactorCode)
             
@@ -60,6 +70,7 @@ def login_route():
 
             if auth_success:
                 # User is authenticated (password correct, and 2FA if needed was correct)
+                clear_failed_logins(client_ip)
                 session_token = create_session(username)
                 session[SESSION_COOKIE_NAME] = session_token # Store token in Flask session
                 response = jsonify({"success": True, "redirect": "/"}) # Add redirect URL
@@ -68,6 +79,9 @@ def login_route():
             elif needs_2fa:
                 # Authentication failed *because* 2FA was required (or code was invalid)
                 # The specific reason (missing vs invalid code) is logged in verify_user
+                # A wrong code counts as a failed attempt; the initial 2FA prompt does not.
+                if twoFactorCode:
+                    record_failed_login(client_ip)
                 logger.warning(f"Login failed for '{username}': 2FA required or invalid.")
                 logger.debug(f"Returning 2FA required response: {{\"success\": False, \"requires_2fa\": True, \"requiresTwoFactor\": True, \"error\": \"Invalid or missing 2FA code\"}}")
                 
@@ -83,6 +97,7 @@ def login_route():
             else:
                 # Authentication failed for other reasons (e.g., wrong password, user not found)
                 # Specific reason logged in verify_user
+                record_failed_login(client_ip)
                 logger.warning(f"Login failed for '{username}': Invalid credentials or other error.")
                 return jsonify({"success": False, "error": "Invalid username or password"}), 401 # Use 401
 

--- a/src/primary/utils/csrf.py
+++ b/src/primary/utils/csrf.py
@@ -1,0 +1,95 @@
+"""Pure CSRF policy helpers (no Flask imports).
+
+Kept in its own module so the policy can be unit-tested without importing
+`web_server`, which touches `/config` at module load.
+"""
+import os
+from urllib.parse import urlparse
+from typing import Optional, Set, Tuple
+
+CSRF_SAFE_METHODS = {'GET', 'HEAD', 'OPTIONS', 'TRACE'}
+
+Origin = Tuple[str, str, int]
+
+
+def normalize_origin(scheme: Optional[str], host_header: Optional[str]) -> Optional[Origin]:
+    """Return (scheme, hostname, port) with the default port resolved from the
+    scheme. Returns None if the input doesn't parse to a usable origin."""
+    if not host_header:
+        return None
+    scheme = (scheme or 'http').lower()
+    parsed = urlparse(f'{scheme}://{host_header}')
+    if not parsed.hostname:
+        return None
+    port = parsed.port
+    if port is None:
+        port = 443 if scheme == 'https' else 80
+    return (scheme, parsed.hostname.lower(), port)
+
+
+def parse_trusted_origins(raw: Optional[str]) -> Tuple[Set[Origin], Set[str]]:
+    """Parse a comma-separated NEWTARR_TRUSTED_ORIGINS value into
+    (full_origins, bare_hostnames).
+
+    Entries with a scheme (e.g. https://example.com:8443) match as full
+    origins (scheme/host/port). Bare hostnames (example.com) match on
+    hostname alone — an explicit operator opt-in for reverse proxies that
+    may rewrite scheme or port.
+    """
+    origins: Set[Origin] = set()
+    hostnames: Set[str] = set()
+    for item in (raw or '').split(','):
+        item = item.strip()
+        if not item:
+            continue
+        if '//' in item:
+            parsed = urlparse(item)
+            origin = normalize_origin(parsed.scheme, parsed.netloc)
+            if origin:
+                origins.add(origin)
+        else:
+            hostnames.add(item.lower())
+    return origins, hostnames
+
+
+def request_allowed(method: str,
+                    source_url: Optional[str],
+                    expected_origin: Optional[Origin],
+                    trusted_origins: Set[Origin],
+                    trusted_hostnames: Set[str]) -> bool:
+    """Pure CSRF policy check. Returns True if the request should be allowed."""
+    if method in CSRF_SAFE_METHODS:
+        return True
+    if not source_url:
+        # No browser-supplied origin — not a CSRF vector (non-browser client).
+        return True
+    parsed = urlparse(source_url)
+    source_origin = normalize_origin(parsed.scheme, parsed.netloc)
+    if not source_origin:
+        return False
+    if expected_origin and source_origin == expected_origin:
+        return True
+    if source_origin in trusted_origins:
+        return True
+    if source_origin[1] in trusted_hostnames:
+        return True
+    return False
+
+
+# Process-lifetime cache for the env-var parse.
+_trusted_cache: Optional[Tuple[Set[Origin], Set[str]]] = None
+
+
+def trusted_origins_from_env() -> Tuple[Set[Origin], Set[str]]:
+    """Cached parse of NEWTARR_TRUSTED_ORIGINS for the current process."""
+    global _trusted_cache
+    if _trusted_cache is None:
+        _trusted_cache = parse_trusted_origins(os.environ.get('NEWTARR_TRUSTED_ORIGINS'))
+    return _trusted_cache
+
+
+def _reset_cache_for_tests() -> None:
+    """Test-only: clear the cached env parse so a test can set the env var
+    and observe the change."""
+    global _trusted_cache
+    _trusted_cache = None

--- a/src/primary/web_server.py
+++ b/src/primary/web_server.py
@@ -7,6 +7,7 @@ Provides a web interface to view logs in real-time, manage settings, and include
 import os
 import datetime
 import time
+from urllib.parse import urlparse
 from threading import Lock
 from primary.utils.logger import LOG_DIR, APP_LOG_FILES, MAIN_LOG_FILE # Import log constants
 from primary import settings_manager # Import settings_manager
@@ -109,6 +110,16 @@ def _get_or_create_secret_key() -> str:
 
 app.secret_key = _get_or_create_secret_key()
 
+# Harden the session cookie. SESSION_COOKIE_SECURE is opt-in (env var) because
+# Newtarr is frequently accessed over plain HTTP on a LAN, where a Secure
+# cookie would never be sent and would break login. Enable it when serving
+# over HTTPS/TLS by setting NEWTARR_SESSION_COOKIE_SECURE=true.
+app.config.update(
+    SESSION_COOKIE_HTTPONLY=True,
+    SESSION_COOKIE_SAMESITE='Lax',
+    SESSION_COOKIE_SECURE=os.environ.get('NEWTARR_SESSION_COOKIE_SECURE', 'false').lower() == 'true',
+)
+
 # Register blueprints
 app.register_blueprint(common_bp)
 app.register_blueprint(sonarr_bp, url_prefix='/api/sonarr')
@@ -122,7 +133,57 @@ app.register_blueprint(stateful_api, url_prefix='/api/stateful')
 app.register_blueprint(history_blueprint, url_prefix='/api/history')
 app.register_blueprint(scheduler_api)
 
-# Register the authentication check to run before requests
+# --- CSRF protection -------------------------------------------------------
+# State-changing requests must originate from Newtarr's own UI. The Origin
+# header (with Referer as a fallback) is verified against the host serving the
+# request. Browsers always send Origin on cross-site POST/form submissions and
+# scripts on a malicious page cannot forge it, so this blocks classic CSRF
+# without per-form tokens. Requests with no Origin/Referer at all are not
+# browser-driven (curl, scripts) and so are not a CSRF vector.
+_CSRF_SAFE_METHODS = {'GET', 'HEAD', 'OPTIONS', 'TRACE'}
+
+
+def _csrf_trusted_hosts():
+    """Extra allowed origin hostnames from the NEWTARR_TRUSTED_ORIGINS env var.
+
+    Needed only when a reverse proxy does not preserve the original Host
+    header. Accepts a comma-separated list of origins or bare hostnames.
+    """
+    hosts = set()
+    for item in os.environ.get('NEWTARR_TRUSTED_ORIGINS', '').split(','):
+        item = item.strip()
+        if not item:
+            continue
+        parsed = urlparse(item if '//' in item else f'//{item}')
+        if parsed.hostname:
+            hosts.add(parsed.hostname.lower())
+    return hosts
+
+
+def csrf_protect():
+    """before_request handler: reject cross-origin state-changing requests."""
+    if request.method in _CSRF_SAFE_METHODS:
+        return None
+
+    source = request.headers.get('Origin') or request.headers.get('Referer')
+    if not source:
+        # No browser-supplied origin — not a CSRF vector (non-browser client).
+        return None
+
+    source_host = urlparse(source).hostname
+    expected_host = urlparse(request.host_url).hostname
+    allowed = {h.lower() for h in (_csrf_trusted_hosts() | {expected_host}) if h}
+    if source_host and source_host.lower() in allowed:
+        return None
+
+    get_logger("web_server").warning(
+        f"Blocked cross-origin {request.method} {request.path} from '{source}'"
+    )
+    return jsonify({"error": "Cross-origin request blocked"}), 403
+
+
+# Register the CSRF check, then the authentication check, to run before requests
+app.before_request(csrf_protect)
 app.before_request(authenticate_request)
 
 @app.after_request

--- a/src/primary/web_server.py
+++ b/src/primary/web_server.py
@@ -7,7 +7,6 @@ Provides a web interface to view logs in real-time, manage settings, and include
 import os
 import datetime
 import time
-from urllib.parse import urlparse
 from threading import Lock
 from primary.utils.logger import LOG_DIR, APP_LOG_FILES, MAIN_LOG_FILE # Import log constants
 from primary import settings_manager # Import settings_manager
@@ -33,8 +32,10 @@ from src.primary.utils.logger import setup_main_logger, get_logger, LOG_DIR, upd
 from src.primary.auth import (
     authenticate_request, user_exists, create_user, verify_user, create_session,
     logout, SESSION_COOKIE_NAME, is_2fa_enabled, generate_2fa_secret,
-    verify_2fa_code, disable_2fa, change_username, change_password
+    verify_2fa_code, disable_2fa, change_username, change_password,
+    _is_local_ip
 )
+from src.primary.utils import csrf as csrf_util
 # Import blueprint for common routes
 from src.primary.routes.common import common_bp
 
@@ -135,45 +136,33 @@ app.register_blueprint(scheduler_api)
 
 # --- CSRF protection -------------------------------------------------------
 # State-changing requests must originate from Newtarr's own UI. The Origin
-# header (with Referer as a fallback) is verified against the host serving the
-# request. Browsers always send Origin on cross-site POST/form submissions and
-# scripts on a malicious page cannot forge it, so this blocks classic CSRF
-# without per-form tokens. Requests with no Origin/Referer at all are not
-# browser-driven (curl, scripts) and so are not a CSRF vector.
-_CSRF_SAFE_METHODS = {'GET', 'HEAD', 'OPTIONS', 'TRACE'}
+# header (with Referer as a fallback) is verified against the origin serving
+# the request, compared as (scheme, hostname, port) — not hostname alone, so
+# another app on the same host but a different port can't forge requests.
+# Pure policy lives in src.primary.utils.csrf and is unit-tested there.
 
-
-def _csrf_trusted_hosts():
-    """Extra allowed origin hostnames from the NEWTARR_TRUSTED_ORIGINS env var.
-
-    Needed only when a reverse proxy does not preserve the original Host
-    header. Accepts a comma-separated list of origins or bare hostnames.
-    """
-    hosts = set()
-    for item in os.environ.get('NEWTARR_TRUSTED_ORIGINS', '').split(','):
-        item = item.strip()
-        if not item:
-            continue
-        parsed = urlparse(item if '//' in item else f'//{item}')
-        if parsed.hostname:
-            hosts.add(parsed.hostname.lower())
-    return hosts
+def _expected_origin():
+    """Origin this request was actually addressed to. Honors X-Forwarded-Proto
+    / X-Forwarded-Host when the direct peer is a local reverse proxy — same
+    trust model used for X-Forwarded-For elsewhere."""
+    scheme = request.scheme
+    host = request.host
+    if _is_local_ip(request.remote_addr):
+        fwd_proto = request.headers.get('X-Forwarded-Proto')
+        if fwd_proto:
+            scheme = fwd_proto.split(',')[0].strip().lower()
+        fwd_host = request.headers.get('X-Forwarded-Host')
+        if fwd_host:
+            host = fwd_host.split(',')[0].strip()
+    return csrf_util.normalize_origin(scheme, host)
 
 
 def csrf_protect():
     """before_request handler: reject cross-origin state-changing requests."""
-    if request.method in _CSRF_SAFE_METHODS:
-        return None
-
     source = request.headers.get('Origin') or request.headers.get('Referer')
-    if not source:
-        # No browser-supplied origin — not a CSRF vector (non-browser client).
-        return None
-
-    source_host = urlparse(source).hostname
-    expected_host = urlparse(request.host_url).hostname
-    allowed = {h.lower() for h in (_csrf_trusted_hosts() | {expected_host}) if h}
-    if source_host and source_host.lower() in allowed:
+    trusted_origins, trusted_hostnames = csrf_util.trusted_origins_from_env()
+    if csrf_util.request_allowed(request.method, source, _expected_origin(),
+                                 trusted_origins, trusted_hostnames):
         return None
 
     get_logger("web_server").warning(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,42 @@
+"""Test-package init. Runs once when any test module is loaded.
+
+Production code touches `/config/...` at import time (auth.py does
+`USER_DIR.mkdir`, utils/logger.py opens a FileHandler under /config/logs).
+Patch both so importing the modules in a test environment without /config
+falls back to a tempdir instead of crashing.
+"""
+import sys
+import pathlib
+import logging
+import tempfile
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+_TEST_DIR = pathlib.Path(tempfile.mkdtemp(prefix='newtarr-test-'))
+
+_real_mkdir = pathlib.Path.mkdir
+
+
+def _safe_mkdir(self, *args, **kwargs):
+    try:
+        return _real_mkdir(self, *args, **kwargs)
+    except (PermissionError, OSError):
+        return None
+
+
+pathlib.Path.mkdir = _safe_mkdir
+
+_real_fh_init = logging.FileHandler.__init__
+_fallback_log = str(_TEST_DIR / 'fallback.log')
+
+
+def _safe_fh_init(self, filename, *args, **kwargs):
+    try:
+        _real_fh_init(self, filename, *args, **kwargs)
+    except (FileNotFoundError, PermissionError):
+        _real_fh_init(self, _fallback_log, *args, **kwargs)
+
+
+logging.FileHandler.__init__ = _safe_fh_init

--- a/tests/test_auth_helpers.py
+++ b/tests/test_auth_helpers.py
@@ -1,0 +1,143 @@
+"""Unit tests for pure helpers in src.primary.auth.
+
+Covers:
+  - _is_local_ip: loopback, link-local, RFC1918/ULA, IPv4-mapped IPv6,
+    public addresses, and malformed input.
+  - _resolve_client_ip: X-Forwarded-For is honored only when the direct
+    peer is itself local (otherwise XFF is attacker-controlled).
+  - Login rate limiter: window enforcement, success clears state, expiry.
+"""
+import time
+import unittest
+from unittest import mock
+
+from src.primary import auth
+
+
+class IsLocalIpTests(unittest.TestCase):
+    def test_loopback_v4(self):
+        self.assertTrue(auth._is_local_ip("127.0.0.1"))
+
+    def test_loopback_v6(self):
+        self.assertTrue(auth._is_local_ip("::1"))
+
+    def test_rfc1918_10(self):
+        self.assertTrue(auth._is_local_ip("10.0.0.5"))
+
+    def test_rfc1918_192_168(self):
+        self.assertTrue(auth._is_local_ip("192.168.1.10"))
+
+    def test_rfc1918_172_16(self):
+        # 172.16/12 — the range string-prefix matching used to miss.
+        self.assertTrue(auth._is_local_ip("172.16.5.5"))
+        self.assertTrue(auth._is_local_ip("172.31.255.254"))
+
+    def test_outside_172_16_block_is_public(self):
+        # 172.32.0.0 is outside the RFC1918 172.16/12 block.
+        self.assertFalse(auth._is_local_ip("172.32.0.1"))
+
+    def test_link_local(self):
+        self.assertTrue(auth._is_local_ip("169.254.1.1"))
+
+    def test_ipv6_ula(self):
+        self.assertTrue(auth._is_local_ip("fd00::1"))
+
+    def test_ipv4_mapped_ipv6_private(self):
+        # ::ffff:192.168.1.5 should unwrap and be treated as local.
+        self.assertTrue(auth._is_local_ip("::ffff:192.168.1.5"))
+
+    def test_ipv4_mapped_ipv6_public(self):
+        self.assertFalse(auth._is_local_ip("::ffff:8.8.8.8"))
+
+    def test_public_v4(self):
+        self.assertFalse(auth._is_local_ip("8.8.8.8"))
+
+    def test_public_v6(self):
+        self.assertFalse(auth._is_local_ip("2001:4860:4860::8888"))
+
+    def test_empty(self):
+        self.assertFalse(auth._is_local_ip(""))
+        self.assertFalse(auth._is_local_ip(None))
+
+    def test_garbage(self):
+        self.assertFalse(auth._is_local_ip("not-an-ip"))
+        self.assertFalse(auth._is_local_ip("999.999.999.999"))
+
+
+class ResolveClientIpTests(unittest.TestCase):
+    def test_no_remote_addr(self):
+        self.assertIsNone(auth._resolve_client_ip(None, None))
+        self.assertIsNone(auth._resolve_client_ip("", "1.2.3.4"))
+
+    def test_no_xff_returns_peer(self):
+        self.assertEqual(auth._resolve_client_ip("8.8.8.8", None), "8.8.8.8")
+
+    def test_xff_honored_when_peer_local(self):
+        # Trusted local proxy forwards the real client.
+        self.assertEqual(
+            auth._resolve_client_ip("10.0.0.1", "8.8.8.8, 10.0.0.1"),
+            "8.8.8.8",
+        )
+
+    def test_xff_ignored_when_peer_public(self):
+        # Public peer claiming to forward a local client must be ignored.
+        self.assertEqual(
+            auth._resolve_client_ip("8.8.8.8", "10.0.0.5"),
+            "8.8.8.8",
+        )
+
+    def test_xff_leftmost_is_client(self):
+        self.assertEqual(
+            auth._resolve_client_ip("127.0.0.1", "1.1.1.1, 2.2.2.2, 127.0.0.1"),
+            "1.1.1.1",
+        )
+
+    def test_empty_xff_falls_back_to_peer(self):
+        self.assertEqual(auth._resolve_client_ip("127.0.0.1", ""), "127.0.0.1")
+        self.assertEqual(auth._resolve_client_ip("127.0.0.1", "   "), "127.0.0.1")
+
+
+class LoginRateLimitTests(unittest.TestCase):
+    def setUp(self):
+        # Isolate the global attempts dict per test.
+        auth._login_attempts.clear()
+
+    def tearDown(self):
+        auth._login_attempts.clear()
+
+    def test_under_limit_not_blocked(self):
+        for _ in range(auth._LOGIN_MAX_ATTEMPTS - 1):
+            auth.record_failed_login("1.2.3.4")
+        self.assertFalse(auth.login_rate_limited("1.2.3.4"))
+
+    def test_at_limit_is_blocked(self):
+        for _ in range(auth._LOGIN_MAX_ATTEMPTS):
+            auth.record_failed_login("1.2.3.4")
+        self.assertTrue(auth.login_rate_limited("1.2.3.4"))
+
+    def test_different_ips_are_independent(self):
+        for _ in range(auth._LOGIN_MAX_ATTEMPTS):
+            auth.record_failed_login("1.2.3.4")
+        self.assertTrue(auth.login_rate_limited("1.2.3.4"))
+        self.assertFalse(auth.login_rate_limited("5.6.7.8"))
+
+    def test_success_clears_attempts(self):
+        for _ in range(auth._LOGIN_MAX_ATTEMPTS):
+            auth.record_failed_login("1.2.3.4")
+        auth.clear_failed_logins("1.2.3.4")
+        self.assertFalse(auth.login_rate_limited("1.2.3.4"))
+
+    def test_window_expiry(self):
+        # Backdate every attempt past the window.
+        old = time.time() - auth._LOGIN_ATTEMPT_WINDOW - 10
+        auth._login_attempts["1.2.3.4"] = [old] * auth._LOGIN_MAX_ATTEMPTS
+        self.assertFalse(auth.login_rate_limited("1.2.3.4"))
+
+    def test_none_ip_is_safe(self):
+        # Defensive: callers might pass None if remote_addr is missing.
+        self.assertFalse(auth.login_rate_limited(None))
+        auth.record_failed_login(None)  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -1,0 +1,173 @@
+"""Unit tests for the CSRF policy helpers (src.primary.utils.csrf)."""
+import os
+import unittest
+from unittest import mock
+
+from src.primary.utils import csrf
+
+
+class NormalizeOriginTests(unittest.TestCase):
+    def test_http_default_port(self):
+        self.assertEqual(
+            csrf.normalize_origin("http", "example.com"),
+            ("http", "example.com", 80),
+        )
+
+    def test_https_default_port(self):
+        self.assertEqual(
+            csrf.normalize_origin("https", "example.com"),
+            ("https", "example.com", 443),
+        )
+
+    def test_explicit_port(self):
+        self.assertEqual(
+            csrf.normalize_origin("http", "example.com:9705"),
+            ("http", "example.com", 9705),
+        )
+
+    def test_case_normalized(self):
+        self.assertEqual(
+            csrf.normalize_origin("HTTPS", "Example.COM:8443"),
+            ("https", "example.com", 8443),
+        )
+
+    def test_missing_inputs(self):
+        self.assertIsNone(csrf.normalize_origin("https", None))
+        self.assertIsNone(csrf.normalize_origin("https", ""))
+
+
+class ParseTrustedOriginsTests(unittest.TestCase):
+    def test_empty(self):
+        origins, hosts = csrf.parse_trusted_origins("")
+        self.assertEqual(origins, set())
+        self.assertEqual(hosts, set())
+
+    def test_none(self):
+        origins, hosts = csrf.parse_trusted_origins(None)
+        self.assertEqual(origins, set())
+        self.assertEqual(hosts, set())
+
+    def test_bare_hostname(self):
+        origins, hosts = csrf.parse_trusted_origins("example.com")
+        self.assertEqual(origins, set())
+        self.assertEqual(hosts, {"example.com"})
+
+    def test_full_origin(self):
+        origins, hosts = csrf.parse_trusted_origins("https://example.com:8443")
+        self.assertEqual(origins, {("https", "example.com", 8443)})
+        self.assertEqual(hosts, set())
+
+    def test_mixed(self):
+        origins, hosts = csrf.parse_trusted_origins(
+            "https://a.example.com, b.example.com ,, https://c:9000"
+        )
+        self.assertEqual(
+            origins,
+            {("https", "a.example.com", 443), ("https", "c", 9000)},
+        )
+        self.assertEqual(hosts, {"b.example.com"})
+
+
+class RequestAllowedTests(unittest.TestCase):
+    EXPECTED = ("http", "newtarr.local", 9705)
+
+    def test_safe_methods_pass(self):
+        for m in ("GET", "HEAD", "OPTIONS", "TRACE"):
+            self.assertTrue(
+                csrf.request_allowed(m, "https://evil.example", self.EXPECTED, set(), set()),
+                f"{m} should be allowed",
+            )
+
+    def test_no_origin_allowed(self):
+        # Non-browser client (curl, scripts) — not a CSRF vector.
+        self.assertTrue(csrf.request_allowed("POST", None, self.EXPECTED, set(), set()))
+        self.assertTrue(csrf.request_allowed("POST", "", self.EXPECTED, set(), set()))
+
+    def test_matching_origin_allowed(self):
+        self.assertTrue(
+            csrf.request_allowed(
+                "POST", "http://newtarr.local:9705/login", self.EXPECTED, set(), set()
+            )
+        )
+
+    def test_different_port_blocked(self):
+        # The codex finding: another app on the same host on port 8080 must
+        # NOT be allowed when our service runs on port 9705.
+        self.assertFalse(
+            csrf.request_allowed(
+                "POST", "http://newtarr.local:8080/", self.EXPECTED, set(), set()
+            )
+        )
+
+    def test_different_scheme_blocked(self):
+        self.assertFalse(
+            csrf.request_allowed(
+                "POST", "https://newtarr.local:9705/", self.EXPECTED, set(), set()
+            )
+        )
+
+    def test_different_host_blocked(self):
+        self.assertFalse(
+            csrf.request_allowed(
+                "POST", "http://evil.example:9705/", self.EXPECTED, set(), set()
+            )
+        )
+
+    def test_trusted_full_origin_allowed(self):
+        trusted = {("https", "proxy.example.com", 443)}
+        self.assertTrue(
+            csrf.request_allowed(
+                "POST", "https://proxy.example.com/", self.EXPECTED, trusted, set()
+            )
+        )
+
+    def test_trusted_full_origin_wrong_port_blocked(self):
+        trusted = {("https", "proxy.example.com", 443)}
+        self.assertFalse(
+            csrf.request_allowed(
+                "POST", "https://proxy.example.com:8443/", self.EXPECTED, trusted, set()
+            )
+        )
+
+    def test_trusted_bare_hostname_allows_any_port(self):
+        # Bare hostname in NEWTARR_TRUSTED_ORIGINS is an explicit operator
+        # opt-in; matches host-only.
+        hostnames = {"proxy.example.com"}
+        self.assertTrue(
+            csrf.request_allowed(
+                "POST", "https://proxy.example.com:8443/", self.EXPECTED, set(), hostnames
+            )
+        )
+
+    def test_malformed_origin_blocked(self):
+        self.assertFalse(
+            csrf.request_allowed("POST", "not-a-url", self.EXPECTED, set(), set())
+        )
+
+
+class TrustedOriginsFromEnvTests(unittest.TestCase):
+    def setUp(self):
+        csrf._reset_cache_for_tests()
+
+    def tearDown(self):
+        csrf._reset_cache_for_tests()
+
+    def test_env_parsed_and_cached(self):
+        with mock.patch.dict(os.environ, {"NEWTARR_TRUSTED_ORIGINS": "https://a.b:8443, x.y"}):
+            origins, hosts = csrf.trusted_origins_from_env()
+            self.assertEqual(origins, {("https", "a.b", 8443)})
+            self.assertEqual(hosts, {"x.y"})
+            # Second call returns the same cached object.
+            self.assertIs(csrf.trusted_origins_from_env()[0], origins)
+
+    def test_cache_survives_env_change(self):
+        with mock.patch.dict(os.environ, {"NEWTARR_TRUSTED_ORIGINS": "a.b"}):
+            first = csrf.trusted_origins_from_env()
+        with mock.patch.dict(os.environ, {"NEWTARR_TRUSTED_ORIGINS": "c.d"}):
+            # Env-var changes mid-process are intentionally ignored (cached).
+            second = csrf.trusted_origins_from_env()
+        self.assertEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the four MEDIUM-severity findings from the repo security audit. Independent of PR #22 (HIGH findings) — no file overlap, either merge order works.

## 1. Session cookie hardening + CSRF protection (`web_server.py`)

State-changing endpoints relied only on the `before_request` session check, and the session cookie had no explicit SameSite policy.

- **Cookie:** `HttpOnly` + `SameSite=Lax`. `Secure` is opt-in via `NEWTARR_SESSION_COOKIE_SECURE=true` — defaulting it on would break login for the common plain-HTTP LAN deployment.
- **CSRF:** a `csrf_protect` before_request handler verifies the `Origin` header (falling back to `Referer`) of every unsafe-method request against the serving host. Browsers always send `Origin` on cross-site POST/form submissions and a malicious page cannot forge it, so this blocks classic CSRF without per-form tokens (no frontend changes, no new dependency). It also protects `local_access_bypass` mode, where there is otherwise no per-request credential.
- Reverse proxies that rewrite `Host` can allowlist origins via `NEWTARR_TRUSTED_ORIGINS`. Both env vars are documented in `AGENTS.md`.

## 2. Proper local-IP detection in `local_access_bypass` (`auth.py`)

`local_access_bypass` matched "local" IPs with naive string prefixes (`'10.'`, `'192.168.'`) — missing `172.16.0.0/12` and IPv4-mapped IPv6 — and had a fall-through bug: a public client arriving through a local reverse proxy was granted bypass anyway, because the `remote_addr` check passed even when `X-Forwarded-For` showed a non-local client.

- Replaced prefix matching with `_is_local_ip()` using the `ipaddress` module (loopback, link-local, RFC1918/ULA, IPv4-mapped IPv6).
- When a trusted local proxy supplies `X-Forwarded-For`, locality is now decided purely from the forwarded client IP — no fall-back to the proxy's own address.

## 3. Login rate limiting (`auth.py`, `common.py`)

`/login` had no brute-force protection. Added an in-memory per-IP rate limiter — 10 failed attempts per 5-minute sliding window, returns 429 when exceeded. Failures are cleared on successful login; a wrong 2FA code counts as a failure, the initial 2FA prompt does not. State is in-memory (single-process Waitress), mirroring `active_sessions`.

## 4. Run the container as non-root (`Dockerfile`)

The Dockerfile chowned `/config` to uid/gid 65532 but never issued a `USER` directive — the runtime user depended entirely on the base-image default. Now sets `USER 65532:65532` explicitly.

## Testing notes

- `python3 -m py_compile` passes on all changed Python files.
- `_is_local_ip`, the CSRF host-match logic, and the rate limiter were unit-tested in isolation (14 IP cases incl. IPv4-mapped IPv6 and 172.16/12; same/cross/trusted/null origin; window expiry).
- I did not run the full app end-to-end (it `mkdir`s `/config` at import time; the `dhi.io` base image is network-restricted in my environment). Worth a manual smoke test before merge: log in, save a setting, confirm the container can still write `/config`.

## Behavior changes to be aware of

- A reverse proxy that does not preserve the `Host` header will have state-changing requests blocked (403) until `NEWTARR_TRUSTED_ORIGINS` is set.
- The `local_access_bypass` fall-through fix means a public client behind a local proxy now correctly requires authentication.
