### PR TITLE
scheduler: resolve UI composite app values to base config targets

### DIFF
--- a/src/primary/scheduler_engine.py
+++ b/src/primary/scheduler_engine.py
@@ -286,6 +286,12 @@ def execute_action(action_entry):
                     add_to_history(action_entry, "error", error_message)
                     return False
 
+        elif not isinstance(action_type, str):
+            error_message = f"Invalid action type: expected string, got {type(action_type).__name__}"
+            scheduler_logger.error(error_message)
+            add_to_history(action_entry, "error", error_message)
+            return False
+
         # Handle the API limit actions based on the predefined values
         elif action_type.startswith("api-") or action_type.startswith("API Limits "):
             # Extract the API limit value from the action type

--- a/src/primary/scheduler_engine.py
+++ b/src/primary/scheduler_engine.py
@@ -26,6 +26,40 @@ SCHEDULE_CHECK_INTERVAL = 60  # Check schedule every minute
 SCHEDULE_DIR = "/config/scheduler"
 SCHEDULE_FILE = os.path.join(SCHEDULE_DIR, "schedule.json")
 
+# Mapping from a schedule entry's `app` field to the base app whose
+# /config/{name}.json file should be mutated, or the literal "global" to fan
+# out across every app. The UI emits composite identifiers such as
+# "sonarr-all" and "whisparr-v3"; those are mapped to their underlying config
+# file here so per-app scheduled actions actually run instead of silently
+# no-op'ing on a non-existent /config/sonarr-all.json.
+SCHEDULE_APP_TARGETS = {
+    "global": "global",
+    "sonarr": "sonarr",
+    "radarr": "radarr",
+    "lidarr": "lidarr",
+    "readarr": "readarr",
+    "whisparr": "whisparr",
+    "eros": "eros",
+    "sonarr-all": "sonarr",
+    "radarr-all": "radarr",
+    "lidarr-all": "lidarr",
+    "readarr-all": "readarr",
+    "whisparr-v2": "whisparr",
+    "whisparr-v3": "eros",
+}
+
+
+def resolve_schedule_target(app_value):
+    """Resolve a schedule entry's `app` value to its target base app name.
+
+    Returns "global" for the global fan-out, a base app name (e.g. "sonarr",
+    "eros") whose /config/{name}.json should be mutated, or None when the
+    value is not a supported scheduler target.
+    """
+    if not isinstance(app_value, str):
+        return None
+    return SCHEDULE_APP_TARGETS.get(app_value)
+
 # Track last executed actions to prevent duplicates
 last_executed_actions = {}
 
@@ -109,7 +143,17 @@ def execute_action(action_entry):
     action_type = action_entry.get("action")
     app_type = action_entry.get("app")
     app_id = action_entry.get("id")
-    
+
+    # Resolve UI-emitted identifiers (e.g. "sonarr-all", "whisparr-v3") to the
+    # underlying config target. `target_app` is what we use to build file
+    # paths and clear caches; `app_type` is preserved for log/history display.
+    target_app = resolve_schedule_target(app_type)
+    if target_app is None:
+        scheduler_logger.debug(
+            f"Skipping scheduled action with unsupported app value: {app_type!r}"
+        )
+        return False
+
     # Generate a unique key for this action to track execution
     current_date = datetime.datetime.now().strftime("%Y-%m-%d")
     execution_key = f"{app_id}_{current_date}"
@@ -125,7 +169,7 @@ def execute_action(action_entry):
         # Handle both old "pause" and new "disable" terminology
         if action_type == "pause" or action_type == "disable":
             # Disable logic for global or specific app
-            if app_type == "global":
+            if target_app == "global":
                 message = "Executing global pause action"
                 scheduler_logger.info(message)
                 try:
@@ -158,7 +202,7 @@ def execute_action(action_entry):
                 message = f"Executing disable action for {app_type}"
                 scheduler_logger.info(message)
                 try:
-                    config_file = f"/config/{app_type}.json"
+                    config_file = f"/config/{target_app}.json"
                     if os.path.exists(config_file):
                         with open(config_file, 'r') as f:
                             config_data = json.load(f)
@@ -172,7 +216,7 @@ def execute_action(action_entry):
                         with open(config_file, 'w') as f:
                             json.dump(config_data, f, indent=2)
                         # Clear cache for this app to ensure the UI refreshes
-                        clear_cache(app_type)
+                        clear_cache(target_app)
                     result_message = f"{app_type} disabled successfully"
                     scheduler_logger.info(result_message)
                     add_to_history(action_entry, "success", result_message)
@@ -181,11 +225,11 @@ def execute_action(action_entry):
                     scheduler_logger.error(error_message)
                     add_to_history(action_entry, "error", error_message)
                     return False
-        
+
         # Handle both old "resume" and new "enable" terminology
         elif action_type == "resume" or action_type == "enable":
             # Enable logic for global or specific app
-            if app_type == "global":
+            if target_app == "global":
                 message = "Executing global enable action"
                 scheduler_logger.info(message)
                 try:
@@ -218,7 +262,7 @@ def execute_action(action_entry):
                 message = f"Executing enable action for {app_type}"
                 scheduler_logger.info(message)
                 try:
-                    config_file = f"/config/{app_type}.json"
+                    config_file = f"/config/{target_app}.json"
                     if os.path.exists(config_file):
                         with open(config_file, 'r') as f:
                             config_data = json.load(f)
@@ -232,7 +276,7 @@ def execute_action(action_entry):
                         with open(config_file, 'w') as f:
                             json.dump(config_data, f, indent=2)
                         # Clear cache for this app to ensure the UI refreshes
-                        clear_cache(app_type)
+                        clear_cache(target_app)
                     result_message = f"{app_type} enabled successfully"
                     scheduler_logger.info(result_message)
                     add_to_history(action_entry, "success", result_message)
@@ -241,7 +285,7 @@ def execute_action(action_entry):
                     scheduler_logger.error(error_message)
                     add_to_history(action_entry, "error", error_message)
                     return False
-        
+
         # Handle the API limit actions based on the predefined values
         elif action_type.startswith("api-") or action_type.startswith("API Limits "):
             # Extract the API limit value from the action type
@@ -251,8 +295,8 @@ def execute_action(action_entry):
                     api_limit = int(action_type.replace("api-", ""))
                 else:
                     api_limit = int(action_type.replace("API Limits ", ""))
-                
-                if app_type == "global":
+
+                if target_app == "global":
                     message = f"Setting global API cap to {api_limit}"
                     scheduler_logger.info(message)
                     try:
@@ -277,7 +321,7 @@ def execute_action(action_entry):
                     message = f"Setting API cap for {app_type} to {api_limit}"
                     scheduler_logger.info(message)
                     try:
-                        config_file = f"/config/{app_type}.json"
+                        config_file = f"/config/{target_app}.json"
                         if os.path.exists(config_file):
                             with open(config_file, 'r') as f:
                                 config_data = json.load(f)

--- a/tests/test_scheduler_target_resolution.py
+++ b/tests/test_scheduler_target_resolution.py
@@ -1,0 +1,57 @@
+"""Unit tests for resolve_schedule_target in src.primary.scheduler_engine."""
+import unittest
+
+from src.primary.scheduler_engine import resolve_schedule_target
+
+
+class ResolveScheduleTargetTests(unittest.TestCase):
+    def test_global_maps_to_global(self):
+        self.assertEqual(resolve_schedule_target("global"), "global")
+
+    def test_bare_base_app_passes_through(self):
+        for app in ("sonarr", "radarr", "lidarr", "readarr", "whisparr", "eros"):
+            with self.subTest(app=app):
+                self.assertEqual(resolve_schedule_target(app), app)
+
+    def test_all_suffix_maps_to_base_app(self):
+        self.assertEqual(resolve_schedule_target("sonarr-all"), "sonarr")
+        self.assertEqual(resolve_schedule_target("radarr-all"), "radarr")
+        self.assertEqual(resolve_schedule_target("lidarr-all"), "lidarr")
+        self.assertEqual(resolve_schedule_target("readarr-all"), "readarr")
+
+    def test_whisparr_versions_route_to_their_config_files(self):
+        # v2 is the legacy "whisparr" config; v3 is the Eros config.
+        self.assertEqual(resolve_schedule_target("whisparr-v2"), "whisparr")
+        self.assertEqual(resolve_schedule_target("whisparr-v3"), "eros")
+
+    def test_unsupported_values_return_none(self):
+        for value in (
+            None,
+            "",
+            123,
+            [],
+            {},
+            "swaparr",  # not a scheduler target
+            "general",  # not a scheduler target
+            "sonarr-1",  # per-instance — not currently supported by the executor
+            "whisparr-v4",
+            "unknownapp-all",
+        ):
+            with self.subTest(value=value):
+                self.assertIsNone(resolve_schedule_target(value))
+
+    def test_traversal_payloads_return_none(self):
+        for value in (
+            "../user/credentials",
+            "sonarr/../etc",
+            "/etc/passwd",
+            "..",
+            "sonarr.json",
+            "sonarr\x00",
+        ):
+            with self.subTest(value=value):
+                self.assertIsNone(resolve_schedule_target(value))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Follow-up to #24 (review thread discussed but deliberately scoped out of that PR). The scheduler UI persists composite `app` values like `sonarr-all`, `radarr-all`, `whisparr-v2`, and `whisparr-v3`, but `execute_action` built `/config/{app}.json` directly from the raw value — so every per-app scheduled action silently no-op'd against a non-existent file (`/config/sonarr-all.json`, etc.), showed up as "success" in history, and never mutated any config.

This PR adds `SCHEDULE_APP_TARGETS` and `resolve_schedule_target()` that map composite identifiers to the base config the action should operate on:

| Stored `app` value | Mutates |
|---|---|
| `global` | all base apps |
| `sonarr` / `sonarr-all` | `/config/sonarr.json` |
| `radarr` / `radarr-all` | `/config/radarr.json` |
| `lidarr` / `lidarr-all` | `/config/lidarr.json` |
| `readarr` / `readarr-all` | `/config/readarr.json` |
| `whisparr` / `whisparr-v2` | `/config/whisparr.json` |
| `eros` / `whisparr-v3` | `/config/eros.json` |
| anything else (`sonarr-2`, garbage, traversal) | quietly skipped |

`execute_action` uses the resolved target for path construction and cache invalidation while keeping the original `app` value for display in log and history messages, so the UI continues to render `Whisparr V3` etc. correctly.

**Behavior change** — flagging explicitly: schedules previously stored from the UI but silently no-op'd will now actually execute. Per-instance values (`sonarr-2`) are intentionally **not** routed here — the engine has no per-instance targeting today, and silently routing them to "all instances" would be surprising. Those continue to skip.

**Interaction with #24:** these touch the same function. If #24 merges first I'll rebase and fold the strict allowlist check into the resolver (the resolver returning non-None already implies the value is a safe scheduler target). If this one merges first, #24's allowlist check becomes simpler since the resolver does most of the work.

## Test plan

- [x] `python -m unittest tests.test_scheduler_target_resolution -v` — 6/6 pass (locally, with mkdir shim; container CI runs it directly).
- [ ] In a running instance, create a schedule with `whisparr-v3` set to `disable` and confirm `/config/eros.json` is updated.
- [ ] Same for `sonarr-all` → `/config/sonarr.json`.
- [ ] Confirm history entries still render the original composite name (`whisparr-v3`, `sonarr-all`) in the UI.
- [ ] Confirm `global` still fans out to all six base apps.
- [ ] Confirm a malformed `app` value (e.g. legacy/unknown) is now quietly skipped instead of erroring.