### PR TITLE
docs(renovate): record why ignoreTests is required here

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "description": "ignoreTests is required here, not a shortcut: release.yml is this repo's only workflow and it triggers on `push: tags: v*.*.*`, so nothing ever runs against a renovate/** branch. GitHub's combined status API reports `pending` when a ref has zero checks, which the inherited :automergeRequireAllStatusChecks (ignoreTests: false) reads as not-green -- every automerge would wait forever. Delete this the moment a pull_request- or branch-triggered CI workflow lands.",
     "extends": [
         "local>jabrown93/.github:renovate-config"
     ],


### PR DESCRIPTION
Part of a Renovate audit across all 17 owned repos. Documentation only — no behavior change.

`ignoreTests: true` reads like a shortcut around the shared preset's `:automergeRequireAllStatusChecks`, and the audit initially flagged it as one. It is not.

`release.yml` is this repo's only workflow and it triggers on `push: tags: v*.*.*`, so nothing ever runs against a `renovate/**` branch. GitHub's combined status API reports `pending` for a ref with zero checks, which `ignoreTests: false` reads as not-green — automerge would wait forever instead of proceeding.

Adds a `description` so the next reader (human or agent) doesn't remove it, and states the condition for deleting it: any `pull_request`- or branch-triggered CI workflow.

Same call as `arr-scripts`. The opposite call was made in `artwork-uploader-plex`, where `ci.yml` does run on `renovate/**` branches and `ignoreTests` was removed as a genuine gap.

`renovate-config-validator` passes.

---
🤖 Authored by Claude (AI agent) at the repo owner's direction.

https://claude.ai/code/session_012gJxRyCGZLCG81R3jNvWes